### PR TITLE
Add configurable GeetestRubySdk.exceptions_to_degraded_mode

### DIFF
--- a/lib/geetest_ruby_sdk.rb
+++ b/lib/geetest_ruby_sdk.rb
@@ -31,6 +31,14 @@ module GeetestRubySdk
     def setup(geetest_id, geetest_key)
       GeetestRubySdk::Account.new geetest_id, geetest_key
     end
+
+    def exceptions_to_degraded_mode
+      @exceptions_to_degraded_mode ||= [
+        RestClient::InternalServerError,
+        RestClient::NotFound,
+        JSON::ParserError
+      ]
+    end
   end
 
   module Rails

--- a/lib/geetest_ruby_sdk/register.rb
+++ b/lib/geetest_ruby_sdk/register.rb
@@ -22,7 +22,7 @@ module GeetestRubySdk
       options = { json_format: GeetestRubySdk::JSON_FORMAT }.merge options.transform_keys(&:to_sym)
       @response = request! payload, options
       on_remote_mode
-    rescue RestClient::InternalServerError, RestClient::NotFound, JSON::ParserError => e
+    rescue *GeetestRubySdk.exceptions_to_degraded_mode => e
       GeetestRubySdk.logger.info "Geetest register request failed for #{e.message}, fall back to degraded mode"
       on_degraded_mode
     end

--- a/spec/geetest_ruby_sdk_spec.rb
+++ b/spec/geetest_ruby_sdk_spec.rb
@@ -11,4 +11,21 @@ RSpec.describe GeetestRubySdk do
   it 'writes log when logger called' do
     expect(described_class.logger.info('This is a message')).equal? 'This is a message'
   end
+
+  describe '#exceptions_to_degraded_mode' do
+    it 'includes three default exceptions' do
+      expect(GeetestRubySdk.exceptions_to_degraded_mode).to include(RestClient::InternalServerError)
+      expect(GeetestRubySdk.exceptions_to_degraded_mode).to include(RestClient::NotFound)
+      expect(GeetestRubySdk.exceptions_to_degraded_mode).to include(JSON::ParserError)
+    end
+
+    context 'after add new exception' do
+      it 'includes added exception' do
+        expect do
+          GeetestRubySdk.exceptions_to_degraded_mode << RestClient::Forbidden
+        end.to change {GeetestRubySdk.exceptions_to_degraded_mode.size}.by(1)
+        expect(GeetestRubySdk.exceptions_to_degraded_mode).to include(RestClient::Forbidden)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What Changed

```
GeetestRubySdk.exceptions_to_degraded_mode << RestClient::Forbidden
```

and then, 403 also can trigger degraded mode